### PR TITLE
Refactored to allow any type secret to be pulled from Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The main motivation of this project is to allow dynamic secrets to be requested 
 
 The implementation should be done so that the pod does not have to understand a specific secret generation tool (e.g. Hashicorp Vault). The application only needs to understand how to read from a file as well as get notified when that file changes.
 
+## Features
+- Dynamically pull usernames & passwords from a MySQL database
+- Fetch static secrets from Vault and mirror as Kubernetes secrets
+
 ## Implementation
 
 This project uses [Vault](https://www.vaultproject.io/) as it's secret distibution tool with the [MySQL Secret Backend](https://www.vaultproject.io/docs/secrets/mysql/index.html) enabled. It's deployed via a custom `ThirdPartyResource` and kubernetes controller which implements the Vault API. Credentials are exposed to pods via simple Kubernetes secrets. The application in the pod is only responsible for refreshing it's application state when those credentials are rotated.
@@ -35,9 +39,7 @@ This project uses [Vault](https://www.vaultproject.io/) as it's secret distibuti
   - Get the vault root token & copy to `args` section in deployment yaml
   - Create deployment: `kubectl create -f deployments/secret-manager.yaml`
 - Create sample app (`kubectl create -f sample-app/deployments/sample-app.yaml`)
-  - NOTE: This creates 2 custom secrets will in turn request two MySQL accounts from Vault, a readonly and full access account. They will be stored in Kubernetes secrets named: `db-readonly-credentials` && `db-full-credentials`
-
-
+  - NOTE: This creates 2 custom secrets will in turn request two MySQL accounts from Vault, a readonly and full access account. It will also request a static secret from Vault. They will be stored in Kubernetes secrets named: `db-readonly-credentials`, `db-full-credentials`, && `foo-secret`
 
 ## Thanks!
 

--- a/deployments/vault.yaml
+++ b/deployments/vault.yaml
@@ -12,7 +12,7 @@ spec:
         app: vault
     spec:
       containers:
-      - image: stevesloka/vault:0.0.1
+      - image: stevesloka/vault:0.0.2
         imagePullPolicy: Always
         name: vault
         ports:

--- a/deployments/vault/setup-vault.sh
+++ b/deployments/vault/setup-vault.sh
@@ -11,3 +11,4 @@ VAULT_ADDR=http://127.0.0.1:8200 vault write mysql/roles/readonly \
    sql="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT SELECT ON *.* TO '{{name}}'@'%';"
 VAULT_ADDR=http://127.0.0.1:8200 vault write mysql/roles/fullaccess \
    sql="CREATE USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';GRANT ALL ON *.* TO '{{name}}'@'%';"
+VAULT_ADDR=http://127.0.0.1:8200 vault write secret/foo value=vault-secret author=sethvargo message=shoutout-to-seth!

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -27,6 +27,8 @@ kubectl exec -it <podName> /bin/dumb-init /bin/sh
 > setup-vault.sh
 ```
 
+Running the above command (`setup-vault.sh`) will do a couple things. First it will create a mysql backend and write some policies to allow us to request credentials from the MySQL server. Also, it will write a sample static secret which will let us mirror that secret as a Kubernetes secret.
+
 #### Vault Configuration
 
 The `setup-vault.sh` script creates some default policies which are configured in the file [myapp.hcl](deployments/vault/myapp.hcl).

--- a/processor.go
+++ b/processor.go
@@ -22,6 +22,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 */
 
+/*
+   Changes
+   2016-09-16: Steve Sloka - Enable custom secrets PR 4
+*/
+
 package main
 
 import (
@@ -170,14 +175,11 @@ func processCustomSecret(c CustomSecret, db *bolt.DB) error {
 		return errors.New("[Processor] Error getting secret from Vault: " + err.Error())
 	}
 
-	// Pull out user/password
-	username, _ := secret.Data["username"].(string)
-	password, _ := secret.Data["password"].(string)
 	c.Spec.LeaseDuration = secret.LeaseDuration
 	c.Spec.LeaseID = secret.LeaseID
 	c.Spec.LeaseExpirationDate = time.Now().Add(time.Second * time.Duration(secret.LeaseDuration))
 
-	err = syncKubernetesSecret(c.Spec.Secret, username, password)
+	err = syncKubernetesSecret(c.Spec.Secret, secret.Data)
 
 	if err != nil {
 		// Delete the Vault secret since we couldn't persist to k8s

--- a/sample-app/deployments/sample-app.yaml
+++ b/sample-app/deployments/sample-app.yaml
@@ -18,6 +18,16 @@ spec:
 
 ---
 
+apiVersion: "enterprises.upmc.com/v1"
+kind: "Customsecrets"
+metadata:
+  name: "foo-secret"
+spec:
+  secret: "foo-secret"
+  policy: "secret/foo"
+
+---
+
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This enables #4 which lets the controller request static secrets from vault. The only assumption now is that secrets stored in Vault are only strings (not files), since there's a conversion of the data to type `string`.
